### PR TITLE
Fix mailcatcher & git config

### DIFF
--- a/provisioning/script.sh
+++ b/provisioning/script.sh
@@ -31,7 +31,7 @@ function prepare_apt() {
     apt update
 
     apt install -y apache2 vim emacs-nox git unzip default-mysql-server imagemagick make nodejs \
-        ruby ruby-dev libsqlite3-dev
+        ruby ruby-dev libsqlite3-dev build-essential
     for version in ${PHP_VERSIONS[@]}; do
         apt install -y \
             libapache2-mod-php${version} \
@@ -123,6 +123,8 @@ function prepare_git_repository() {
         git clone https://github.com/PrestaShop/PrestaShop.git prestashop
         pushd prestashop
         git config core.fileMode false
+        git config user.email "vagrant@prestashop.com"
+        git config user.name "vagrant"
         popd
         popd
     fi
@@ -143,7 +145,7 @@ function prepare_branch() {
 
 function prepare_mailcatcher() {
     gem install mailcatcher
-    pkill -f mailcatcher
+    pkill -f mailcatcher || true
     mailcatcher --ip 192.168.42.42
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | To be able to install `mailcatcher`, `build-essential` must be installed. Also, when `mailcatcher` is not running `pkill` will return false and the vagran provisionning will fail.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 1. run `vagrant up` and check that it works<br>2. Find a PR in develop branch and run `PR={pr_number} BRANCH=develop vagrant up --provision`
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
